### PR TITLE
Removed "from ." in front of module imports

### DIFF
--- a/crisp/calibration.py
+++ b/crisp/calibration.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('crisp')
 import numpy as np
 import scipy.optimize
 
-from . import videoslice, rotations, ransac, timesync, fastintegrate
+import videoslice, rotations, ransac, timesync, fastintegrate
 
 PARAM_SOURCE_ORDER = ('user', 'initialized', 'calibrated') # Increasing order of importance
 PARAM_ORDER = ('gyro_rate', 'time_offset', 'gbias_x', 'gbias_y', 'gbias_z', 'rot_x', 'rot_y', 'rot_z')

--- a/crisp/imu.py
+++ b/crisp/imu.py
@@ -17,9 +17,9 @@ import re
 
 import scipy.io
 
-from . import rotations
-from . import fastintegrate
-from . import l3g4200d
+import rotations
+import fastintegrate
+import l3g4200d
 #--------------------------------------------------------------------------
 # Classes
 #--------------------------------------------------------------------------

--- a/crisp/pose.py
+++ b/crisp/pose.py
@@ -15,9 +15,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 import cv2
 
-from . import timesync
-from . import tracking
-from . import rotations
+import timesync
+import tracking
+import rotations
 
 def estimate_pose(image_sequences, imu_sequences, K):
     """Estimate sync between IMU and camera based on gyro readings and optical flow.

--- a/crisp/rotations.py
+++ b/crisp/rotations.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from numpy.testing import assert_almost_equal
 
-from . import ransac
+import ransac
 
 #------------------------------------------------------------------------------
 

--- a/crisp/stream.py
+++ b/crisp/stream.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('crisp')
 import cv2
 import numpy as np
 
-from . import fastintegrate, tracking
+import fastintegrate, tracking
 
 class GyroStream(object):
     def __init__(self):

--- a/crisp/timesync.py
+++ b/crisp/timesync.py
@@ -22,10 +22,10 @@ import scipy.signal as ssig
 import scipy.optimize
 from matplotlib.mlab import normpdf
 
-from . import tracking
-from .imu import IMU
-from . import rotations
-from . import znccpyr
+import tracking
+from imu import IMU
+import rotations
+import znccpyr
 
 #--------------------------------------------------------------------------
 # Public functions

--- a/crisp/videoslice.py
+++ b/crisp/videoslice.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 import cv2
 import numpy as np
 
-from . import rotations
-from . import tracking
+import rotations
+import tracking
         
 class Slice(object):
     def __init__(self, start, end, points):


### PR DESCRIPTION
With "from ." I'm unable to execute crisp on my Arch Linux system.
